### PR TITLE
fix env example file name

### DIFF
--- a/content/homepage/run_it_yourself.md
+++ b/content/homepage/run_it_yourself.md
@@ -8,7 +8,7 @@ header_menu: true
 
 ```
 $ earthly -P +build --area=Amsterdam
-$ cp .env-example .env
+$ cp .env.example .env
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
The file in the repo is `.env.example` and not `.env-example`, so running the command `$ cp .env-example .env` will raise an error from cp

![image](https://user-images.githubusercontent.com/19731161/188629683-51c79abc-d208-4747-b491-ba6afaaf66d2.png)

https://github.com/headwaymaps/headway/blob/main/.env.example